### PR TITLE
Use Meta class mechanism to generate fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,18 @@ animal_df = pd.DataFrame(
 You can then create a marshmallow schema that will validate and load dataframes
 that follow the same structure as the one above and that have been serialized
 with `DataFrame.to_json` with the [`orient=split`
-format](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_json.html#pandas.DataFrame.to_json):
+format](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_json.html#pandas.DataFrame.to_json).
+The `dtypes` attribute of the `Meta` class is required, and other [`marshmallow`
+Schema
+options](https://marshmallow.readthedocs.io/en/latest/api_reference.html#marshmallow.Schema.Meta)
+can also be passed as attributes of `Meta`:
 
 ```python
 class AnimalSchema(SplitDataFrameSchema):
     """Automatically generated schema for animal dataframe"""
 
-    dtypes = animal_df.dtypes
+    class Meta:
+        dtypes = animal_df.dtypes
 ```
 
 When passing a valid payload for a new animal, this schema will validate it and

--- a/src/marshmallow_dataframe/dataframe.py
+++ b/src/marshmallow_dataframe/dataframe.py
@@ -89,6 +89,18 @@ class DataFrameSchemaOpts(ma.SchemaOpts):
 class DataFrameSchemaMeta(ma.schema.SchemaMeta):
     """Base metaclass for DataFrame schemas"""
 
+    def __new__(meta, name, bases, class_dict):
+        """Only validate subclasses of our schemas"""
+        klass = super().__new__(meta, name, bases, class_dict)
+
+        if bases != (ma.Schema,) and klass.opts.dtypes is None:
+            raise ValueError(
+                "Subclasses of marshmallow_dataframe Schemas must define "
+                "the `dtypes` Meta option"
+            )
+
+        return klass
+
     @classmethod
     def get_declared_fields(
         mcs, klass, cls_fields, inherited_fields, dict_cls

--- a/src/marshmallow_dataframe/dataframe.py
+++ b/src/marshmallow_dataframe/dataframe.py
@@ -121,7 +121,7 @@ class RecordsDataFrameSchemaMeta(DataFrameSchemaMeta):
         mcs, opts: DataFrameSchemaOpts, dict_cls
     ) -> Dict[str, ma.fields.Field]:
 
-        if opts.dtypes is not None and opts.index_dtype is not None:
+        if opts.dtypes is not None:
             dtypes = _validate_dtypes(opts.dtypes)
 
             # create marshmallow fields
@@ -150,7 +150,7 @@ class SplitDataFrameSchemaMeta(DataFrameSchemaMeta):
         mcs, opts: DataFrameSchemaOpts, dict_cls
     ) -> Dict[str, ma.fields.Field]:
 
-        if opts.dtypes is not None and opts.index_dtype is not None:
+        if opts.dtypes is not None:
             dtypes = _validate_dtypes(opts.dtypes)
             index_dtype = opts.index_dtype
 
@@ -185,6 +185,8 @@ class SplitDataFrameSchemaMeta(DataFrameSchemaMeta):
 class RecordsDataFrameSchema(ma.Schema, metaclass=RecordsDataFrameSchemaMeta):
     """Schema to generate pandas DataFrame from list of records"""
 
+    OPTIONS_CLASS = DataFrameSchemaOpts
+
     @ma.post_load
     def make_df(self, data: dict) -> pd.DataFrame:
         records_data = data["data"]
@@ -196,8 +198,10 @@ class RecordsDataFrameSchema(ma.Schema, metaclass=RecordsDataFrameSchemaMeta):
         )
 
 
-class SplitDataFrameSchema(ma.Schema):
+class SplitDataFrameSchema(ma.Schema, metaclass=SplitDataFrameSchemaMeta):
     """Schema to generate pandas DataFrame from split oriented JSON"""
+
+    OPTIONS_CLASS = DataFrameSchemaOpts
 
     @ma.validates_schema(skip_on_field_errors=True)
     def validate_index_data_length(self, data: dict) -> None:

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -49,6 +49,18 @@ def serialize_df(df, orient="split"):
 @pytest.mark.parametrize(
     "base_class", [SplitDataFrameSchema, RecordsDataFrameSchema]
 )
+def test_schema_no_dtypes(base_class):
+
+    with pytest.raises(
+        ValueError, match="must define the `dtypes` Meta option"
+    ):
+        class NewSchema(base_class):
+            pass
+
+
+@pytest.mark.parametrize(
+    "base_class", [SplitDataFrameSchema, RecordsDataFrameSchema]
+)
 def test_schema_wrong_dtypes(base_class):
     with pytest.raises(ValueError, match="must be either a pandas Series or"):
         class NewSchema(base_class):

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -54,6 +54,7 @@ def test_schema_no_dtypes(base_class):
     with pytest.raises(
         ValueError, match="must define the `dtypes` Meta option"
     ):
+
         class NewSchema(base_class):
             pass
 
@@ -63,6 +64,7 @@ def test_schema_no_dtypes(base_class):
 )
 def test_schema_wrong_dtypes(base_class):
     with pytest.raises(ValueError, match="must be either a pandas Series or"):
+
         class NewSchema(base_class):
             class Meta:
                 dtypes = "wrong type for dtypes"

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -64,7 +64,8 @@ def test_schema_no_dtypes(base_class):
 )
 def test_schema_wrong_dtypes(base_class):
     class NewSchema(base_class):
-        dtypes = "wrong type for dtypes"
+        class Meta:
+            dtypes = "wrong type for dtypes"
 
     with pytest.raises(ValueError, match="must be either a pandas Series or"):
         NewSchema()
@@ -72,9 +73,12 @@ def test_schema_wrong_dtypes(base_class):
 
 def test_records_schema(sample_df):
     class MySchema(RecordsDataFrameSchema):
-        dtypes = sample_df.dtypes
+        class Meta:
+            dtypes = sample_df.dtypes
 
     schema = MySchema()
+
+    print(schema._declared_fields)
 
     output = schema.load(serialize_df(sample_df, orient="records"))
 
@@ -244,8 +248,9 @@ def test_records_schema_missing_data_field():
 @pytest.fixture
 def split_sample_schema(sample_df):
     class MySchema(SplitDataFrameSchema):
-        dtypes = sample_df.dtypes
-        index_dtype = sample_df.index.dtype
+        class Meta:
+            dtypes = sample_df.dtypes
+            index_dtype = sample_df.index.dtype
 
     return MySchema()
 
@@ -305,8 +310,9 @@ def test_split_schema_hypothesis(test_df):
         return
 
     class MySchema(SplitDataFrameSchema):
-        dtypes = test_df.dtypes
-        index_dtype = test_df.index.dtype
+        class Meta:
+            dtypes = test_df.dtypes
+            index_dtype = test_df.index.dtype
 
     schema = MySchema()
 
@@ -332,8 +338,9 @@ def test_split_schema_str_index(sample_df):
     test_df.index = test_df.index.astype(str)
 
     class MySchema(SplitDataFrameSchema):
-        dtypes = test_df.dtypes
-        index_dtype = test_df.index.dtype
+        class Meta:
+            dtypes = test_df.dtypes
+            index_dtype = test_df.index.dtype
 
     schema = MySchema()
 

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -49,26 +49,11 @@ def serialize_df(df, orient="split"):
 @pytest.mark.parametrize(
     "base_class", [SplitDataFrameSchema, RecordsDataFrameSchema]
 )
-def test_schema_no_dtypes(base_class):
-    class NewSchema(base_class):
-        pass
-
-    with pytest.raises(
-        NotImplementedError, match="must define the `dtypes` attribute"
-    ):
-        NewSchema()
-
-
-@pytest.mark.parametrize(
-    "base_class", [SplitDataFrameSchema, RecordsDataFrameSchema]
-)
 def test_schema_wrong_dtypes(base_class):
-    class NewSchema(base_class):
-        class Meta:
-            dtypes = "wrong type for dtypes"
-
     with pytest.raises(ValueError, match="must be either a pandas Series or"):
-        NewSchema()
+        class NewSchema(base_class):
+            class Meta:
+                dtypes = "wrong type for dtypes"
 
 
 def test_records_schema(sample_df):
@@ -119,7 +104,8 @@ def test_records_schema_hypothesis(test_df):
         return
 
     class MySchema(RecordsDataFrameSchema):
-        dtypes = test_df.dtypes
+        class Meta:
+            dtypes = test_df.dtypes
 
     schema = MySchema()
 
@@ -134,7 +120,8 @@ def test_records_schema_hypothesis(test_df):
 
 def test_records_schema_missing_column(sample_df):
     class MySchema(RecordsDataFrameSchema):
-        dtypes = sample_df.dtypes
+        class Meta:
+            dtypes = sample_df.dtypes
 
     schema = MySchema()
 
@@ -155,7 +142,8 @@ def test_records_schema_missing_column(sample_df):
 
 def test_records_schema_wrong_type(sample_df):
     class MySchema(RecordsDataFrameSchema):
-        dtypes = sample_df.dtypes
+        class Meta:
+            dtypes = sample_df.dtypes
 
     schema = MySchema()
 
@@ -177,7 +165,8 @@ def test_records_schema_nulls():
     test_dtypes = pd.Series(index=["float"], data=[np.dtype(np.float)])
 
     class MySchema(RecordsDataFrameSchema):
-        dtypes = test_dtypes
+        class Meta:
+            dtypes = test_dtypes
 
     schema = MySchema()
 
@@ -195,7 +184,8 @@ def test_records_schema_nulls():
 )
 def test_records_schema_invalid_input_type_iter(input_data):
     class MySchema(RecordsDataFrameSchema):
-        dtypes = Dtypes(columns=["float"], dtypes=[np.dtype(np.float)])
+        class Meta:
+            dtypes = Dtypes(columns=["float"], dtypes=[np.dtype(np.float)])
 
     schema = MySchema()
 
@@ -212,7 +202,8 @@ def test_records_schema_invalid_input_type_iter(input_data):
 )
 def test_records_schema_invalid_input_type_notiter(input_data):
     class MySchema(RecordsDataFrameSchema):
-        dtypes = Dtypes(columns=["float"], dtypes=[np.dtype(np.float)])
+        class Meta:
+            dtypes = Dtypes(columns=["float"], dtypes=[np.dtype(np.float)])
 
     schema = MySchema()
 
@@ -222,7 +213,8 @@ def test_records_schema_invalid_input_type_notiter(input_data):
 
 def test_records_schema_none():
     class MySchema(RecordsDataFrameSchema):
-        dtypes = Dtypes(columns=["float"], dtypes=[np.dtype(np.float)])
+        class Meta:
+            dtypes = Dtypes(columns=["float"], dtypes=[np.dtype(np.float)])
 
     schema = MySchema()
 
@@ -232,7 +224,8 @@ def test_records_schema_none():
 
 def test_records_schema_missing_data_field():
     class MySchema(RecordsDataFrameSchema):
-        dtypes = Dtypes(columns=["float"], dtypes=[np.dtype(np.float)])
+        class Meta:
+            dtypes = Dtypes(columns=["float"], dtypes=[np.dtype(np.float)])
 
     schema = MySchema()
 


### PR DESCRIPTION
This is the preferred way of configuring fields in marshmallow schemas as opposed to the undocumented way that we were using before to generate the fields based on the dataframe dtypes.