### PR TITLE
split format: Make index field optional if index_dtype is not specified

### DIFF
--- a/src/marshmallow_dataframe/split.py
+++ b/src/marshmallow_dataframe/split.py
@@ -31,7 +31,11 @@ class SplitDataFrameSchemaMeta(DataFrameSchemaMeta):
                 else dtype_to_field(index_dtype)
             )
 
-            fields["index"] = ma.fields.List(index_field, required=True)
+            index_required = False if index_dtype is None else True
+
+            fields["index"] = ma.fields.List(
+                index_field, required=index_required
+            )
 
             fields["columns"] = ma.fields.List(
                 ma.fields.String,
@@ -51,7 +55,10 @@ class SplitDataFrameSchema(ma.Schema, metaclass=SplitDataFrameSchemaMeta):
 
     @ma.validates_schema(skip_on_field_errors=True)
     def validate_index_data_length(self, data: dict, **kwargs) -> None:
-        if len(data["index"]) != len(data["data"]):
+        if (
+                data.get("index") is not None and
+                len(data["index"]) != len(data["data"])
+        ):
             raise ma.ValidationError(
                 "Length of `index` and `data` must be equal.", "data"
             )

--- a/src/marshmallow_dataframe/split.py
+++ b/src/marshmallow_dataframe/split.py
@@ -55,9 +55,8 @@ class SplitDataFrameSchema(ma.Schema, metaclass=SplitDataFrameSchemaMeta):
 
     @ma.validates_schema(skip_on_field_errors=True)
     def validate_index_data_length(self, data: dict, **kwargs) -> None:
-        if (
-                data.get("index") is not None and
-                len(data["index"]) != len(data["data"])
+        if data.get("index") is not None and len(data["index"]) != len(
+            data["data"]
         ):
             raise ma.ValidationError(
                 "Length of `index` and `data` must be equal.", "data"

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -114,6 +114,23 @@ def test_split_schema_missing_top_level_key(
     assert exc.value.messages[key] == ["Missing data for required field."]
 
 
+@pytest.mark.parametrize("require_index", [True, False])
+def test_optional_index_field(sample_df, require_index):
+    class MySchema(SplitDataFrameSchema):
+        class Meta:
+            dtypes = sample_df.dtypes
+            index_dtype = sample_df.index.dtype if require_index else None
+
+    serialized_df = serialize_df(sample_df, orient="split")
+
+    if not require_index:
+        del serialized_df["index"]
+
+    output = MySchema().load(serialized_df)
+
+    assert_frame_equal(output, sample_df)
+
+
 def test_split_schema_str_index(sample_df):
     test_df = sample_df.copy()
     test_df.index = test_df.index.astype(str)


### PR DESCRIPTION
With this change, the `index` field in the serialized JSON is only required when the user has specified a `index_dtype` when building the Schema.

Fixes #18. 